### PR TITLE
Remove inputenc

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -3,7 +3,6 @@
 \errorcontextlines=9999
 
 \usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
 
 \usepackage{absint}
 \usepackage[prefix=]{xcolor-material}


### PR DESCRIPTION
Since 2018, utf-8 is the default input encoding. Thus, there should be no need to load it.

- https://tex.stackexchange.com/a/370279/9075
- https://tug.org/TUGboat/tb39-1/tb121ltnews28.pdf